### PR TITLE
Apply black formatting to all Python files

### DIFF
--- a/custom_components/sandman_doppler/__init__.py
+++ b/custom_components/sandman_doppler/__init__.py
@@ -95,10 +95,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             hw_version=doppler.device_info.firmware_version,
             name=doppler.name,
         )
-        hass.data[DOMAIN][entry.entry_id][
-            doppler.dsn
-        ] = coordinator = DopplerDataUpdateCoordinator(
-            hass, entry, client, doppler, dev_entry
+        hass.data[DOMAIN][entry.entry_id][doppler.dsn] = coordinator = (
+            DopplerDataUpdateCoordinator(hass, entry, client, doppler, dev_entry)
         )
         hass.async_create_task(coordinator.async_refresh())
 

--- a/custom_components/sandman_doppler/binary_sensor.py
+++ b/custom_components/sandman_doppler/binary_sensor.py
@@ -1,4 +1,5 @@
 """Sensor platform for Doppler Sandman."""
+
 from __future__ import annotations
 
 from collections.abc import Callable

--- a/custom_components/sandman_doppler/config_flow.py
+++ b/custom_components/sandman_doppler/config_flow.py
@@ -1,4 +1,5 @@
 """Adds config flow for Doppler."""
+
 from __future__ import annotations
 
 from doppyler.client import DopplerClient

--- a/custom_components/sandman_doppler/const.py
+++ b/custom_components/sandman_doppler/const.py
@@ -1,4 +1,5 @@
 """Constants for Sandman Doppler Clocks."""
+
 # Base component constants
 NAME = "Sandman Doppler"
 DOMAIN = "sandman_doppler"

--- a/custom_components/sandman_doppler/device_trigger.py
+++ b/custom_components/sandman_doppler/device_trigger.py
@@ -1,4 +1,5 @@
 """Provides device triggers for sandman_doppler."""
+
 from __future__ import annotations
 
 from typing import Any

--- a/custom_components/sandman_doppler/entity.py
+++ b/custom_components/sandman_doppler/entity.py
@@ -1,4 +1,5 @@
 """Doppler light platform."""
+
 from __future__ import annotations
 
 from typing import Any, Generic, TypeVar

--- a/custom_components/sandman_doppler/helpers.py
+++ b/custom_components/sandman_doppler/helpers.py
@@ -1,4 +1,5 @@
 """Helpers for Sandman Doppler Clocks."""
+
 from enum import Enum
 
 

--- a/custom_components/sandman_doppler/http.py
+++ b/custom_components/sandman_doppler/http.py
@@ -1,4 +1,5 @@
 """HTTP views for Sandman Doppler."""
+
 from __future__ import annotations
 
 from http import HTTPStatus

--- a/custom_components/sandman_doppler/light.py
+++ b/custom_components/sandman_doppler/light.py
@@ -1,4 +1,5 @@
 """Light platform for Doppler Sandman."""
+
 from __future__ import annotations
 
 from collections.abc import Callable, Coroutine
@@ -55,9 +56,9 @@ class DopplerLightEntityDescription(LightEntityDescription):
     color_key: str | None = None
     set_color_func: Callable[[Doppler, Color], Coroutine[Any, Any, Any]] | None = None
     brightness_key: str | None = None
-    set_brightness_func: Callable[
-        [Doppler, int], Coroutine[Any, Any, int]
-    ] | None = None
+    set_brightness_func: Callable[[Doppler, int], Coroutine[Any, Any, int]] | None = (
+        None
+    )
 
 
 LIGHT_ENTITY_DESCRIPTIONS = [
@@ -146,14 +147,14 @@ def get_sync_light_types(
 
 
 def get_opposite_day_or_night(
-    day_or_night: Literal["day", "night"]
+    day_or_night: Literal["day", "night"],
 ) -> Literal["day", "night"]:
     """Return the opposite day or night."""
     return "day" if day_or_night == "night" else "night"
 
 
 def get_opposite_button_or_display(
-    button_or_display: Literal["button", "display"]
+    button_or_display: Literal["button", "display"],
 ) -> Literal["button", "display"]:
     """Return the opposite button or display."""
     return "button" if button_or_display == "display" else "display"
@@ -208,9 +209,9 @@ class BaseDopplerLight(DopplerEntity[DopplerLightEntityDescription], LightEntity
         """Set brightness on device."""
         brightness *= 100
         brightness //= 255
-        brightness = self.device_data[
-            self.ed.brightness_key
-        ] = await self.ed.set_brightness_func(self.device, brightness)
+        brightness = self.device_data[self.ed.brightness_key] = (
+            await self.ed.set_brightness_func(self.device, brightness)
+        )
         return brightness
 
     async def _async_set_rgb_color(self, rgb_color: list[int]) -> Color:

--- a/custom_components/sandman_doppler/number.py
+++ b/custom_components/sandman_doppler/number.py
@@ -1,4 +1,5 @@
 """Number platform for Doppler Sandman."""
+
 from __future__ import annotations
 
 from collections.abc import Callable, Coroutine

--- a/custom_components/sandman_doppler/select.py
+++ b/custom_components/sandman_doppler/select.py
@@ -1,4 +1,5 @@
 """Select platform for Doppler Sandman."""
+
 from __future__ import annotations
 
 from collections.abc import Callable, Coroutine

--- a/custom_components/sandman_doppler/sensor.py
+++ b/custom_components/sandman_doppler/sensor.py
@@ -1,4 +1,5 @@
 """Sensor platform for Doppler Sandman."""
+
 from __future__ import annotations
 
 from collections.abc import Callable

--- a/custom_components/sandman_doppler/services.py
+++ b/custom_components/sandman_doppler/services.py
@@ -1,4 +1,5 @@
 """The Sandman Doppler services module."""
+
 from __future__ import annotations
 
 import asyncio

--- a/custom_components/sandman_doppler/siren.py
+++ b/custom_components/sandman_doppler/siren.py
@@ -1,4 +1,5 @@
 """Siren platform for Doppler Sandman."""
+
 from __future__ import annotations
 
 from collections.abc import Callable, Coroutine

--- a/custom_components/sandman_doppler/switch.py
+++ b/custom_components/sandman_doppler/switch.py
@@ -1,4 +1,5 @@
 """Switch platform for Doppler Sandman."""
+
 from __future__ import annotations
 
 from collections.abc import Callable, Coroutine, Mapping

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 """Global fixtures for sandman_doppler integration."""
+
 from unittest.mock import patch
 
 import pytest


### PR DESCRIPTION
## Summary

Run black formatter on all Python files to ensure consistent code style and pass CI style checks.

## Changes

15 files reformatted with black.

🤖 Generated with [Claude Code](https://claude.com/claude-code)